### PR TITLE
Update: se añade method para enriquecer los Logs

### DIFF
--- a/Bacheton.Application/Logs/Common/LogResult.cs
+++ b/Bacheton.Application/Logs/Common/LogResult.cs
@@ -8,4 +8,5 @@ public record LogResult(
     string? TraceId, 
     string? Duration,
     string? UserId,
-    string Level);
+    string Level,
+    string? Method);

--- a/Bacheton.Infrastructure/Common/Logging/SeqLogRepository.cs
+++ b/Bacheton.Infrastructure/Common/Logging/SeqLogRepository.cs
@@ -25,6 +25,7 @@ public class SeqLogRepository : ILogRepository
         {
             var requestPath = e.Properties?.FirstOrDefault(p => p.Name == "RequestPath")?.Value?.ToString();
             var status = e.Properties?.FirstOrDefault(p => p.Name == "StatusCode")?.Value?.ToString();
+            var method = e.Properties?.FirstOrDefault(p => p.Name == "RequestMethod")?.Value?.ToString();
 
             return new LogResult(
                 Id: e.Id,
@@ -34,7 +35,8 @@ public class SeqLogRepository : ILogRepository
                 TraceId: e.TraceId,
                 Duration: e.Properties?.FirstOrDefault(p => p.Name == "Elapsed")?.Value?.ToString(),
                 UserId: e.Properties?.FirstOrDefault(p => p.Name == "UserId")?.Value?.ToString(),
-                Level: e.Level
+                Level: e.Level,
+                Method: method
             );
         }).ToList();
 


### PR DESCRIPTION
Implementación de visualización del HTTP Method en logs

- Se agregó el campo 'Method' en el DTO 'LogResult' para incluir el método HTTP (GET, POST, etc.) proveniente de los logs almacenados en Seq.
- Se actualizó la clase 'SeqLogRepository' para mapear y devolver el valor de 'RequestMethod' desde las propiedades del log.
- Ahora la API expone, junto con el resto de la información, el método HTTP utilizado en cada solicitud registrada.
- Este cambio permitirá una mejor trazabilidad y filtrado de logs por tipo de método en las implementaciones frontend.
